### PR TITLE
Encode the URL to protect against breacking characters

### DIFF
--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -367,7 +367,14 @@ export default {
   },
   methods: {
     goToCollaboraAdmin() {
-        window.open('https://admin:'+this.admin_password + '@' + this.host + '/browser/dist/admin/adminSettings.html');
+      const username = "admin";
+      const password = encodeURIComponent(this.admin_password);
+      const host = this.host;
+      const path = "/browser/dist/admin/adminSettings.html";
+
+      const url = `https://${username}:${password}@${host}${path}`;
+
+      window.open(url);
     },
     async getConfiguration() {
       this.loading.getConfiguration = true;


### PR DESCRIPTION
When we use some characters like `/` in the password we break the button to reach the admin page, we should encode the url