### PR TITLE
Store admin password in separate file

### DIFF
--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -42,12 +42,8 @@ password = data.get("admin_password", "")
 agent.set_env("TRAEFIK_HOST", host)
 agent.set_env("TRAEFIK_HTTP2HTTPS", h2hs)
 agent.set_env("TRAEFIK_LETS_ENCRYPT", le)
-agent.set_env("ADMIN_PASSWORD", password)
-password = {"ADMIN_PASSWORD": password}
-agent.write_envfile("password.env", password)
-# Make sure everything is saved inside the environment file
-# just before starting systemd unit
-agent.dump_env()
+agent.write_envfile("password.env", {"password": password})
+
 
 # Find default traefik instance for current node
 default_traefik_id = agent.resolve_agent_id('traefik@node')

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -43,7 +43,8 @@ agent.set_env("TRAEFIK_HOST", host)
 agent.set_env("TRAEFIK_HTTP2HTTPS", h2hs)
 agent.set_env("TRAEFIK_LETS_ENCRYPT", le)
 agent.set_env("ADMIN_PASSWORD", password)
-
+password = {"ADMIN_PASSWORD": password}
+agent.write_envfile("password.env", password)
 # Make sure everything is saved inside the environment file
 # just before starting systemd unit
 agent.dump_env()

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -26,8 +26,7 @@ import agent
 
 # Prepare return variable
 config = {}
-
-config["admin_password"] =  os.environ.get("ADMIN_PASSWORD",'')
+config["admin_password"] = agent.read_envfile("password.env")["ADMIN_PASSWORD"] if os.path.exists("password.env") else ""
 config["host"] = os.environ.get("TRAEFIK_HOST",'')
 config["http2https"] =  os.environ.get("TRAEFIK_HTTP2HTTPS","False") == "True"
 config["lets_encrypt"] =  os.environ.get("TRAEFIK_LETS_ENCRYPT","False") == "True"

--- a/imageroot/actions/get-configuration/20read
+++ b/imageroot/actions/get-configuration/20read
@@ -26,7 +26,12 @@ import agent
 
 # Prepare return variable
 config = {}
-config["admin_password"] = agent.read_envfile("password.env")["ADMIN_PASSWORD"] if os.path.exists("password.env") else ""
+
+if os.path.exists("password.env"):
+    config["admin_password"] = agent.read_envfile("password.env")["password"]
+else:
+    config["admin_password"] = ""
+
 config["host"] = os.environ.get("TRAEFIK_HOST",'')
 config["http2https"] =  os.environ.get("TRAEFIK_HTTP2HTTPS","False") == "True"
 config["lets_encrypt"] =  os.environ.get("TRAEFIK_LETS_ENCRYPT","False") == "True"

--- a/imageroot/systemd/user/collabora.service
+++ b/imageroot/systemd/user/collabora.service
@@ -4,7 +4,6 @@ Description=Podman  collabora.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
-EnvironmentFile=%S/state/password.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70
@@ -14,7 +13,7 @@ ExecStart=/usr/bin/podman run --conmon-pidfile %t/collabora.pid \
     --replace -d --name  collabora --cap-add MKNOD \
     --env aliasgroup2=https://${TRAEFIK_HOST}:443 \
     --env username=admin \
-    --env password=${ADMIN_PASSWORD} \
+    --env-file=%S/state/password.env \
     --env "extra_params=--o:ssl.enable=false --o:ssl.termination=true --o:security.capabilities=false" \
     --env dictionnaries="de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru" \
     --publish 127.0.0.1:${TCP_PORT}:9980 \

--- a/imageroot/systemd/user/collabora.service
+++ b/imageroot/systemd/user/collabora.service
@@ -4,6 +4,7 @@ Description=Podman  collabora.service
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 EnvironmentFile=%S/state/environment
+EnvironmentFile=%S/state/password.env
 WorkingDirectory=%S/state
 Restart=always
 TimeoutStopSec=70

--- a/imageroot/update-module.d/10upgrade_password
+++ b/imageroot/update-module.d/10upgrade_password
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+import sys
+import agent
+import os
+
+# perform the upgrade from collabora:1.0.5
+
+# Get the ADMIN_PASSWORD environment variable
+admin_password = os.getenv('ADMIN_PASSWORD')
+
+# Define the path for the password file
+password_file_path = os.path.expanduser('~/.config/state/password.env')
+
+if admin_password:
+    # Write the ADMIN_PASSWORD to the file
+    password = {"ADMIN_PASSWORD": admin_password}
+    agent.write_envfile("password.env", password)
+
+    # Check if the file is not empty
+    if os.path.getsize(password_file_path) > 0:
+        print("Password file of collabora created", file=sys.stderr)
+        agent.unset_env("ADMIN_PASSWORD")
+    else:
+        print(agent.SD_WARNING + "Error Password file of collabora is empty", file=sys.stderr)
+        exit(1)

--- a/imageroot/update-module.d/10upgrade_password
+++ b/imageroot/update-module.d/10upgrade_password
@@ -13,18 +13,6 @@ import os
 # Get the ADMIN_PASSWORD environment variable
 admin_password = os.getenv('ADMIN_PASSWORD')
 
-# Define the path for the password file
-password_file_path = os.path.expanduser('~/.config/state/password.env')
-
 if admin_password:
-    # Write the ADMIN_PASSWORD to the file
-    password = {"ADMIN_PASSWORD": admin_password}
-    agent.write_envfile("password.env", password)
-
-    # Check if the file is not empty
-    if os.path.getsize(password_file_path) > 0:
-        print("Password file of collabora created", file=sys.stderr)
-        agent.unset_env("ADMIN_PASSWORD")
-    else:
-        print(agent.SD_WARNING + "Error Password file of collabora is empty", file=sys.stderr)
-        exit(1)
+    agent.write_envfile("password.env", {"password": admin_password})
+    agent.unset_env("ADMIN_PASSWORD")


### PR DESCRIPTION
This pull request adds functionality to store the admin password in a separate file called "password.env". Storing the password in a separate file improves security and allows for easier management of the password.

https://github.com/NethServer/dev/issues/6969