### PR TITLE
Remove unused ADMIN_PASSWORD environment variable and add state/password.env to backup include patterns

### DIFF
--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -31,7 +31,6 @@ for evar in [
         "TRAEFIK_HOST",
         "TRAEFIK_HTTP2HTTPS",
         "TRAEFIK_LETS_ENCRYPT",
-        "ADMIN_PASSWORD",
     ]:
     agent.set_env(evar, original_environment[evar])
 

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -1,0 +1,7 @@
+#
+#  state/backup include patterns for Restic
+# Syntax reference: https://pkg.go.dev/path/filepath#Glob
+# Restic --files-from: https://restic.readthedocs.io/en/stable/040_backup.html#including-files
+# List here what you want to save during backup : volumes or file Path
+
+state/password.env


### PR DESCRIPTION
This pull request includes two commits. The first commit removes the unused ADMIN_PASSWORD environment variable. The second commit adds the file state/password.env to the backup include patterns.

https://github.com/NethServer/dev/issues/7003