### PR TITLE
Enable host loopback for Collabora service network

### DIFF
--- a/imageroot/systemd/user/collabora.service
+++ b/imageroot/systemd/user/collabora.service
@@ -11,6 +11,7 @@ ExecStartPre=/bin/rm -f %t/collabora.pid %t/collabora.ctr-id
 ExecStart=/usr/bin/podman run --conmon-pidfile %t/collabora.pid \
     --cidfile %t/collabora.ctr-id --cgroups=no-conmon \
     --replace -d --name  collabora --cap-add MKNOD \
+    --network=slirp4netns:allow_host_loopback=true \
     --env aliasgroup2=https://${TRAEFIK_HOST}:443 \
     --env username=admin \
     --env-file=%S/state/password.env \


### PR DESCRIPTION
Configure the Collabora service to allow host loopback in its network settings.

https://github.com/NethServer/dev/issues/7197