### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -12,7 +12,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://www.collaboraoffice.com/code/",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/collabora.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-collabora"
   },


### PR DESCRIPTION
This pull request updates the documentation URL in the `metadata.json` file to point to the correct location for Collabora documentation.

* [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL15-R15): Updated the `documentation_url` to `https://docs.nethserver.org/projects/ns8/en/latest/collabora.html` to ensure users are directed to the appropriate documentation.

https://github.com/NethServer/dev/issues/7399